### PR TITLE
Adding point bounty to tasks

### DIFF
--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -23,7 +23,9 @@ class Api::ActionsController < Api::ApiController
           user.tasks << task
 
           public_message = "*The fantastic @#{user.name} just completed his/her " +
-            "#{user.tasks.count.ordinalize} to-do:* 🎉\n#{task.description}"
+            "#{user.tasks.count.ordinalize} to-do and earned #{task.bounty} " +
+            "#{"point".pluralize(task.bounty)} for a total of " +
+            "#{user.tasks.sum(:bounty)}:* 🎉\n#{task.description}"
           send_message public_message
 
           confirmation_message = "✅ *Nice job! You finished this to-do " +

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -32,7 +32,9 @@ class Api::ApiController < ApplicationController
     }).parsed_response
   end
 
-  def new_task_message(task, text: "*🐣 Here’s a task for you to do...*")
+  def new_task_message(task, text: "🐣 Here’s a task for you to do...")
+    text = "#{text} (earn #{task.bounty} #{"point".pluralize(task.bounty)})"
+
     {
       "text": text,
       "attachments": [

--- a/db/migrate/20170104021122_add_bounty_to_tasks.rb
+++ b/db/migrate/20170104021122_add_bounty_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddBountyToTasks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tasks, :bounty, :integer
+  end
+end

--- a/db/migrate/20170104021122_add_bounty_to_tasks.rb
+++ b/db/migrate/20170104021122_add_bounty_to_tasks.rb
@@ -1,5 +1,7 @@
 class AddBountyToTasks < ActiveRecord::Migration[5.0]
   def change
-    add_column :tasks, :bounty, :integer
+    add_column :tasks, :bounty, :integer, default: 1
+    Task.reset_column_information
+    Task.update_all bounty: 1
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 20170104021122) do
     t.boolean  "has_expired",  default: false, null: false
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
-    t.integer  "bounty"
+    t.integer  "bounty",       default: 1
     t.index ["has_expired"], name: "index_tasks_on_has_expired", using: :btree
     t.index ["is_multi_use"], name: "index_tasks_on_is_multi_use", using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161220061736) do
+ActiveRecord::Schema.define(version: 20170104021122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 20161220061736) do
     t.boolean  "has_expired",  default: false, null: false
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
+    t.integer  "bounty"
     t.index ["has_expired"], name: "index_tasks_on_has_expired", using: :btree
     t.index ["is_multi_use"], name: "index_tasks_on_is_multi_use", using: :btree
   end

--- a/test/controllers/api/actions_controller_test.rb
+++ b/test/controllers/api/actions_controller_test.rb
@@ -48,7 +48,7 @@ class Api::ActionsControllerTest < ActionController::TestCase
         token: SLACK_AUTH_TOKEN,
         channel: SLACK_GENERAL_CHANNEL_ID,
         text: "*The fantastic @#{@user.name} just completed his/her " +
-          "1st to-do:* 🎉\n#{@task.description}"
+          "1st to-do and earned 1 point for a total of 1:* 🎉\n#{@task.description}"
       }
     }).returns(stubbed_response)
 

--- a/test/controllers/api/actions_controller_test.rb
+++ b/test/controllers/api/actions_controller_test.rb
@@ -94,7 +94,7 @@ class Api::ActionsControllerTest < ActionController::TestCase
     parsed_response = JSON.parse(response.body)
 
     assert_response :success
-    assert_equal "Try this one on for size...", parsed_response['text']
+    assert_equal "Try this one on for size... (earn 1 point)", parsed_response['text']
     assert_equal 1, parsed_response['attachments'].size
     assert_equal 2, parsed_response['attachments'][0]['actions'].size
     assert_equal new_task.description, parsed_response['attachments'][0]['text']

--- a/test/controllers/api/get_tasks_controller_test.rb
+++ b/test/controllers/api/get_tasks_controller_test.rb
@@ -20,7 +20,7 @@ class Api::GetTasksControllerTest < ActionController::TestCase
     parsed_response = JSON.parse(response.body)
 
     assert_response :success
-    assert_equal "*🐣 Here’s a task for you to do...*", parsed_response['text']
+    assert_equal "🐣 Here’s a task for you to do... (earn 1 point)", parsed_response['text']
     assert_equal 1, parsed_response['attachments'].size
     assert_equal 2, parsed_response['attachments'][0]['actions'].size
     assert_equal @task.description, parsed_response['attachments'][0]['text']


### PR DESCRIPTION
Adding a `bounty` column to the tasks table (default: 1). Use the admin dashboard to modify a task's point values. Points are earned when the task is completed (assigned to the user).